### PR TITLE
feat: use iso8601 date format

### DIFF
--- a/packages/publish-config/src/index.js
+++ b/packages/publish-config/src/index.js
@@ -361,10 +361,7 @@ export const publish = async (options) => {
       .join('\n\n')
   })
 
-  const date = new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(Date.now())
+  const date = `${new Date().toISOString().split('T')[0]} ${new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit' }).format(Date.now())}`
 
   const changelogMd = [
     `Version ${version} - ${date}${tag ? ' (Manual Release)' : ''}`,


### PR DESCRIPTION
1. Make date section unambiguous (e.g 5/6/2025 can be interpreted as may 6th or june 5th)
2. Make time section locale independent (undefined uses machine's default locale)